### PR TITLE
Don't call `setup.py install`, use `pip install .`

### DIFF
--- a/py-pkgs/chapters/03-package-structure.ipynb
+++ b/py-pkgs/chapters/03-package-structure.ipynb
@@ -186,7 +186,7 @@
     "This will create an archive file (`.tar.gz` by default) of your project which is your `sdist`. If your code is pure Python then an `sdist` is a perfectly acceptable way to distribute your code, and a user could install it using:\n",
     "\n",
     "```bash\n",
-    "$ python setup.py install\n",
+    "$ pip install .\n",
     "```\n",
     "\n",
     "You could also share your `sdist` to PyPI from which a user could install it using `pip install`. It's important to note that installing a package actually adds the package to your default installation directory (more on that in {ref}`03-installed-packages`) such that it is accessible outside of your working directory - this is a key difference to simply sharing code as a module or package as we explored in the last two sections. We recommend consulting the [The Hitchhiker's Guide to Packaging](https://the-hitchhikers-guide-to-packaging.readthedocs.io/en/latest/creation.html#) and the [Python docs](https://docs.python.org/3/distutils/sourcedist.html) for more information on creating and distributing source distributions. Some notable examples of Python `sdists` include: [Django](https://github.com/django/django), [hyperlink](https://github.com/python-hyper/hyperlink), and [requests](https://github.com/psf/requests)."


### PR DESCRIPTION
calling setup.py directly is not recommended it has several drawbacks:

  - it can break pip that cannot always "see" the package is
  installed, or may make it hard to uninstall/update.

  - It suffer from the "dependency needed to run setup.py" (pep 517)

  - It does not work for project that do not use setup.py.

`pip install .` is the recommended way, it will do "the right thing",
regardless of context.


-- 

In particular later (and before as well) you point to poetry (I would also recommend [flit](http://flit.readthedocs.org/) which is even simpler than poetry), and pyproject.toml, for which  `pip install .` should work is pyproject.toml has the right values.

