### PR TITLE
Add missing '-r' to pip install cmd in README.md's 'Build the book' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A practical book on how to distribute Python code via Python packages - availabl
 If you'd like develop and build the py-pkgs book from source, you should:
 
 - Clone this repository and run
-- Run `pip install requirements.txt` (it is recommended you do this within a virtual environment)
+- Run `pip install -r requirements.txt` (it is recommended you do this within a virtual environment)
 - (Recommended) Clean the existing `jupyter-book clean py-pkgs/` directory
 - Run `jupyter-book build py-pkgs/`
 


### PR DESCRIPTION
#### Description:

This pull-request adds missing '-r' to pip install cmd in README.md's 'Build the book' section
`pip install -r requirements.txt`

=====
Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
 
 