### PR TITLE
Applying new referencing format

### DIFF
--- a/py-pkgs/00-authors.ipynb
+++ b/py-pkgs/00-authors.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(00:about-the-authors)=\n",
+    "(00:About the authors)=\n",
     "# About the authors"
    ]
   },

--- a/py-pkgs/00-preface.ipynb
+++ b/py-pkgs/00-preface.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(00:preface)=\n",
+    "(00:Preface)=\n",
     "# Preface"
    ]
   },
@@ -49,15 +49,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Chapter 1: {ref}`01:introduction`** first gives a brief introduction to packages in Python and why you should know how to make them. **Chapter 2: {ref}`02:system-setup`** describes how to set up your development environment to develop packages and follow along with the remainder of the book. In **Chapter 3: {ref}`03:how-to-package-a-python`**, we will develop a small toy package from end-to-end to get a feel for the steps involved in the packaging process and to understand the final product we are aiming for. The remaining chapters then unpack this workflow and go into more details about each step in the packaging process, organised roughly in their order in the workflow:\n",
+    "**Chapter 1: {ref}`01:Introduction`** first gives a brief introduction to packages in Python and why you should know how to make them. **Chapter 2: {ref}`02:System setup`** describes how to set up your development environment to develop packages and follow along with the remainder of the book. In **Chapter 3: {ref}`03:How to package a Python`**, we will develop a small toy package from end-to-end to get a feel for the steps involved in the packaging process and to understand the final product we are aiming for. The remaining chapters then unpack this workflow and go into more details about each step in the packaging process, organised roughly in their order in the workflow:\n",
     "\n",
-    "- **Chapter 4: {ref}`04:package-structure-and-state`** \n",
-    "- **Chapter 5: {ref}`05:testing`**\n",
-    "- **Chapter 6: {ref}`06:documentation`**\n",
-    "- **Chapter 7: {ref}`07:releasing-and-versioning`**\n",
-    "- **Chapter 8: {ref}`08:continuous-integration-and-deployment`**\n",
-    "- **Appendix 1: {ref}`A1:packages-with-a-command-line-interface`**\n",
-    "- **Appendix 2: {ref}`A2:python-packaging-cheat-sheet`**"
+    "- **Chapter 4: {ref}`04:Package structure and state`** \n",
+    "- **Chapter 5: {ref}`05:Testing`**\n",
+    "- **Chapter 6: {ref}`06:Documentation`**\n",
+    "- **Chapter 7: {ref}`07:Releasing and versioning`**\n",
+    "- **Chapter 8: {ref}`08:Continuous integration and deployment`**\n",
+    "- **Appendix 1: {ref}`A1:Packages with a command line interface`**\n",
+    "- **Appendix 2: {ref}`A2:Python packaging cheat sheet`**"
    ]
   },
   {
@@ -136,7 +136,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Python software ecosystem is constantly evolving. While the packaging workflows and concepts discussed in this book are effectively tool-agnostic, the tools we do use in the book may have been updated by the time you read it. If the maintainers of these tools are doing the right thing by documenting, versioning, and properly deprecating their code (we'll explore these concepts ourselves in Chapter 7: {ref}`07:releasing-and-versioning`), then it should be straightforward to adapt any outdated code in the book."
+    "The Python software ecosystem is constantly evolving. While the packaging workflows and concepts discussed in this book are effectively tool-agnostic, the tools we do use in the book may have been updated by the time you read it. If the maintainers of these tools are doing the right thing by documenting, versioning, and properly deprecating their code (we'll explore these concepts ourselves in **Chapter 7: {ref}`07:Releasing and versioning`**), then it should be straightforward to adapt any outdated code in the book."
    ]
   },
   {

--- a/py-pkgs/00-preface.ipynb
+++ b/py-pkgs/00-preface.ipynb
@@ -49,15 +49,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Chapter 1: {ref}`01:Introduction`** first gives a brief introduction to packages in Python and why you should know how to make them. **Chapter 2: {ref}`02:System setup`** describes how to set up your development environment to develop packages and follow along with the remainder of the book. In **Chapter 3: {ref}`03:How to package a Python`**, we will develop a small toy package from end-to-end to get a feel for the steps involved in the packaging process and to understand the final product we are aiming for. The remaining chapters then unpack this workflow and go into more details about each step in the packaging process, organised roughly in their order in the workflow:\n",
+    "**Chapter 1: {ref}`01:Introduction`** first gives a brief introduction to packages in Python and why you should know how to make them. **Chapter 2: {ref}`02:System-setup`** describes how to set up your development environment to develop packages and follow along with the remainder of the book. In **Chapter 3: {ref}`03:How-to-package-a-Python`**, we will develop a small toy package from end-to-end to get a feel for the steps involved in the packaging process and to understand the final product we are aiming for. The remaining chapters then unpack this workflow and go into more details about each step in the packaging process, organised roughly in their order in the workflow:\n",
     "\n",
-    "- **Chapter 4: {ref}`04:Package structure and state`** \n",
+    "- **Chapter 4: {ref}`04:Package-structure-and-state`** \n",
     "- **Chapter 5: {ref}`05:Testing`**\n",
     "- **Chapter 6: {ref}`06:Documentation`**\n",
-    "- **Chapter 7: {ref}`07:Releasing and versioning`**\n",
-    "- **Chapter 8: {ref}`08:Continuous integration and deployment`**\n",
-    "- **Appendix 1: {ref}`A1:Packages with a command line interface`**\n",
-    "- **Appendix 2: {ref}`A2:Python packaging cheat sheet`**"
+    "- **Chapter 7: {ref}`07:Releasing-and-versioning`**\n",
+    "- **Chapter 8: {ref}`08:Continuous-integration-and-deployment`**\n",
+    "- **Appendix 1: {ref}`A1:Packages-with-a-command-line-interface`**\n",
+    "- **Appendix 2: {ref}`A2:Python-packaging-cheat-sheet`**"
    ]
   },
   {
@@ -136,7 +136,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Python software ecosystem is constantly evolving. While the packaging workflows and concepts discussed in this book are effectively tool-agnostic, the tools we do use in the book may have been updated by the time you read it. If the maintainers of these tools are doing the right thing by documenting, versioning, and properly deprecating their code (we'll explore these concepts ourselves in **Chapter 7: {ref}`07:Releasing and versioning`**), then it should be straightforward to adapt any outdated code in the book."
+    "The Python software ecosystem is constantly evolving. While the packaging workflows and concepts discussed in this book are effectively tool-agnostic, the tools we do use in the book may have been updated by the time you read it. If the maintainers of these tools are doing the right thing by documenting, versioning, and properly deprecating their code (we'll explore these concepts ourselves in **Chapter 7: {ref}`07:Releasing-and-versioning`**), then it should be straightforward to adapt any outdated code in the book."
    ]
   },
   {

--- a/py-pkgs/01-introduction.ipynb
+++ b/py-pkgs/01-introduction.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(01:introduction)=\n",
+    "(01:Introduction)=\n",
     "# Introduction"
    ]
   },

--- a/py-pkgs/02-setup.ipynb
+++ b/py-pkgs/02-setup.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(02:system-setup)=\n",
+    "(02:System setup)=\n",
     "# System setup"
    ]
   },

--- a/py-pkgs/02-setup.ipynb
+++ b/py-pkgs/02-setup.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(02:System setup)=\n",
+    "(02:System-setup)=\n",
     "# System setup"
    ]
   },

--- a/py-pkgs/03-how-to-package-a-python.ipynb
+++ b/py-pkgs/03-how-to-package-a-python.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(03:how-to-package-a-python)=\n",
+    "(03:How to package a Python)=\n",
     "# How to package a Python"
    ]
   },
@@ -26,7 +26,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The first thing to do is create a directory structure for our Python package. Without getting too technical, a Python package is just a structured of one or more modules. So that we don't have to create this structure from scratch, we will use Cookiecutter & Poetry to do this for us (both of which you installed back in {ref}`02:system-setup`).\n",
+    "The first thing to do is create a directory structure for our Python package. Without getting too technical, a Python package is just a structured of one or more modules. So that we don't have to create this structure from scratch, we will use Cookiecutter & Poetry to do this for us (both of which you installed back in **Chapter 2: {ref}`02:System setup`**).\n",
     "\n",
     "Cookiecutter is a tool for populating a file and directory structure from a pre-made template. We have developed our own [Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) which is based off the template by the [PyOpenSci](https://www.pyopensci.org/) organization for creating Python packages (PyOpenSci is a not-for-profit organization that promotes open and reproducible research through peer-review of scientific Python packages). To use our Cookiecutter template to set up the structure of your Python package, open up a terminal session, change into the directory where you want your package to live and run the line of code below:\n",
     "\n",
@@ -312,7 +312,7 @@
    "metadata": {},
    "source": [
     "```{tip}\n",
-    "Pandas comes packaged with the Anaconda distribution we installed in {ref}`02:system-setup`. However, if for some reason you don't currently have Pandas installed, you can install it with `pip` or `conda`, check out the official [Pandas documentation](https://pandas.pydata.org/docs/getting_started/install.html).\n",
+    "Pandas comes packaged with the Anaconda distribution we installed in **Chapter 2: {ref}`02:System setup`**. However, if for some reason you don't currently have Pandas installed, you can install it with `pip` or `conda`, check out the official [Pandas documentation](https://pandas.pydata.org/docs/getting_started/install.html).\n",
     "```\n",
     "\n",
     "This error occurs because the categoricals are represented as integers in memory, and in the variable `a`, the integer 0 corresponds to the word \"character\" while in `b`, the integer 0 corresponds to the word \"but\". Thus, when we ask Python to concatenate these two Pandas categorical options it doesn't know what to do with these integer mappings to different categories, and so it throws an error. We can get around this several ways, one way is to convert the Pandas categoricals to a `str` type, then do the concatenation, and finally convert the concatenated Pandas obeject back to a categorical again. We demonstrate that approach below:"
@@ -578,7 +578,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the users of your code (including your future self) we need to have readable and accessible documentation expressing how to install your package, and how to use the functions within it. We'll discuss documentation in detail in the chapter {ref}`06:documentation`, but for now, we will demonstrate the basic steps required to get your documentation up-and-running quickly.\n",
+    "For the users of your code (including your future self) we need to have readable and accessible documentation expressing how to install your package, and how to use the functions within it. We'll discuss documentation in detail in **Chapter 6: {ref}`06:Documentation`**, but for now, we will demonstrate the basic steps required to get your documentation up-and-running quickly.\n",
     "\n",
     "The Python packaging ecosystem has a tool to help you easily make documentation - [Sphinx](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html). In the Cookiecutter template we used to define our package's directory structure, there is a basic docs template that the Cookiecutter progam filled in with the information you entered interactively when you ran `cookiecutter https://github.com/UBC-MDS/cookiecutter-ubc-mds.git`. These files live in the `docs` directory and are `.rst` (reStructuredText markup language) filetype. This is a lightweight markup language that works similar to Markdown but uses different syntax. The templates provided to you here are fairly well formatted already, so you do not have to change the `.rst` formatting, however if you are interested in doing so, you can see the [Sphinx documentation](https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html) to get started.\n",
     "\n",
@@ -627,7 +627,7 @@
     "File not found error!\n",
     "```\n",
     "\n",
-    "This is because we haven't written any documentation for our package function. Let's do that now by adding a `NumPy`-style docstring to the `catbind` function in `pypkgs/pypkgs.py` as shown below (we'll discuss docstring style more in the chapter {ref}`06:documentation`):\n",
+    "This is because we haven't written any documentation for our package function. Let's do that now by adding a `NumPy`-style docstring to the `catbind` function in `pypkgs/pypkgs.py` as shown below (we'll discuss docstring style more in **Chapter 6: {ref}`06:Documentation`**):\n",
     "\n",
     "```python\n",
     "import pandas as pd\n",
@@ -752,7 +752,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have interactively taken `catbind` for a test drive, but to prove to our future self and others that our code does in fact do what it is supposed to do, let's write some formal unit tests. We'll discuss testing in detail in the {ref}`05:testing` chapter, but will go over the key steps here. In Python packages, our tests live inside the `test` directory, typically in a file called `test_<module_name>.py`, thus for this package this is `tests/test_pypkgs.py`. Let's add a unit test (as a function named `test_catbind`) for our `catbind` function there now:\n",
+    "We have interactively taken `catbind` for a test drive, but to prove to our future self and others that our code does in fact do what it is supposed to do, let's write some formal unit tests. We'll discuss testing in detail in **Chapter 5: {ref}`05:Testing`**, but will go over the key steps here. In Python packages, our tests live inside the `test` directory, typically in a file called `test_<module_name>.py`, thus for this package this is `tests/test_pypkgs.py`. Let's add a unit test (as a function named `test_catbind`) for our `catbind` function there now:\n",
     "\n",
     "```python\n",
     "from pypkgs import __version__\n",
@@ -832,7 +832,7 @@
     "poetry config repositories.test-pypi https://test.pypi.org/legacy/\n",
     "```\n",
     "\n",
-    "Before we send our package, we first need to build it to source and wheel distributions (the format that PyPI distributes and something you'll learn more about in the next chapter {ref}`04:package-structure-and-state`) using `poetry build`:\n",
+    "Before we send our package, we first need to build it to source and wheel distributions (the format that PyPI distributes and something you'll learn more about in **Chapter 4: {ref}`04:Package structure and state`**) using `poetry build`:\n",
     "\n",
     "```bash\n",
     "poetry build\n",

--- a/py-pkgs/03-how-to-package-a-python.ipynb
+++ b/py-pkgs/03-how-to-package-a-python.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(03:How to package a Python)=\n",
+    "(03:How-to-package-a-Python)=\n",
     "# How to package a Python"
    ]
   },
@@ -26,7 +26,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The first thing to do is create a directory structure for our Python package. Without getting too technical, a Python package is just a structured of one or more modules. So that we don't have to create this structure from scratch, we will use Cookiecutter & Poetry to do this for us (both of which you installed back in **Chapter 2: {ref}`02:System setup`**).\n",
+    "The first thing to do is create a directory structure for our Python package. Without getting too technical, a Python package is just a structured of one or more modules. So that we don't have to create this structure from scratch, we will use Cookiecutter & Poetry to do this for us (both of which you installed back in **Chapter 2: {ref}`02:System-setup`**).\n",
     "\n",
     "Cookiecutter is a tool for populating a file and directory structure from a pre-made template. We have developed our own [Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) which is based off the template by the [PyOpenSci](https://www.pyopensci.org/) organization for creating Python packages (PyOpenSci is a not-for-profit organization that promotes open and reproducible research through peer-review of scientific Python packages). To use our Cookiecutter template to set up the structure of your Python package, open up a terminal session, change into the directory where you want your package to live and run the line of code below:\n",
     "\n",
@@ -312,7 +312,7 @@
    "metadata": {},
    "source": [
     "```{tip}\n",
-    "Pandas comes packaged with the Anaconda distribution we installed in **Chapter 2: {ref}`02:System setup`**. However, if for some reason you don't currently have Pandas installed, you can install it with `pip` or `conda`, check out the official [Pandas documentation](https://pandas.pydata.org/docs/getting_started/install.html).\n",
+    "Pandas comes packaged with the Anaconda distribution we installed in **Chapter 2: {ref}`02:System-setup`**. However, if for some reason you don't currently have Pandas installed, you can install it with `pip` or `conda`, check out the official [Pandas documentation](https://pandas.pydata.org/docs/getting_started/install.html).\n",
     "```\n",
     "\n",
     "This error occurs because the categoricals are represented as integers in memory, and in the variable `a`, the integer 0 corresponds to the word \"character\" while in `b`, the integer 0 corresponds to the word \"but\". Thus, when we ask Python to concatenate these two Pandas categorical options it doesn't know what to do with these integer mappings to different categories, and so it throws an error. We can get around this several ways, one way is to convert the Pandas categoricals to a `str` type, then do the concatenation, and finally convert the concatenated Pandas obeject back to a categorical again. We demonstrate that approach below:"
@@ -832,7 +832,7 @@
     "poetry config repositories.test-pypi https://test.pypi.org/legacy/\n",
     "```\n",
     "\n",
-    "Before we send our package, we first need to build it to source and wheel distributions (the format that PyPI distributes and something you'll learn more about in **Chapter 4: {ref}`04:Package structure and state`**) using `poetry build`:\n",
+    "Before we send our package, we first need to build it to source and wheel distributions (the format that PyPI distributes and something you'll learn more about in **Chapter 4: {ref}`04:Package-structure-and-state`**) using `poetry build`:\n",
     "\n",
     "```bash\n",
     "poetry build\n",

--- a/py-pkgs/04-package-structure.ipynb
+++ b/py-pkgs/04-package-structure.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(04:package-structure-and-state)=\n",
+    "(04:Package structure and state)=\n",
     "# Package structure and state"
    ]
   },
@@ -145,7 +145,7 @@
     "A \"distribution package\" (often referred to simply as a \"distribution\") is a single archive of the Python packages, modules and other files that make up your project. Having a single archive makes it easier to distribute your code to the world. The fundamental distribution format is called a \"source distribution\" (`sdist`). An `sdist` is a compressed archive (e.g., `.tar.gz` or `.zip`) of your package. Essentially, an `sdist` provides all of the metadata and source files needed for building and installing your package. You can read more about source distributions [here](https://docs.python.org/3/distutils/sourcedist.html). The standard tool in Python for creating `sdists` (and binary distributions, which we'll explore in the next section) is `setuptools`. \n",
     "\n",
     "```{note}\n",
-    "As we saw in {ref}`03:how-to-package-a-python`, we prefer to use `poetry` to create distribution packages of our Python code, as a simpler and more intuitive alternative to `setuptools`. We'll discuss Poetry a little later.\n",
+    "As we saw in **Chapter 3: {ref}`03:How to package a Python`**, we prefer to use `poetry` to create distribution packages of our Python code, as a simpler and more intuitive alternative to `setuptools`. We'll discuss Poetry a little later.\n",
     "```\n",
     "\n",
     "As a very simple example, consider the following directory which now contains a `setup.py` file.\n",
@@ -246,11 +246,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The previous sections gave a high level overview of Python's standard packaging options and tools. However, in {ref}`03:how-to-package-a-python` we used `poetry` to create a toy Python package - so where does this tool fit into the Python packaging landscape? Well, in the previous sections, we really only touched the tip of the iceberg of Python packaging. When creating a package there's a lot of customisation to think about with your `setup.py` file, and a host of other files we didn't even talk about (e.g., `requirements.txt`, `setup.cfg`, etc)! Needless to say, packaging in Python can be hard to understand, especially for beginners. These words echo the sentiments of `poetry's` creator Sébastien Eustace and the motivation for creating the tool:\n",
+    "The previous sections gave a high level overview of Python's standard packaging options and tools. However, in **Chapter 3: {ref}`03:How to package a Python`** we used `poetry` to create a toy Python package - so where does this tool fit into the Python packaging landscape? Well, in the previous sections, we really only touched the tip of the iceberg of Python packaging. When creating a package there's a lot of customisation to think about with your `setup.py` file, and a host of other files we didn't even talk about (e.g., `requirements.txt`, `setup.cfg`, etc)! Needless to say, packaging in Python can be hard to understand, especially for beginners. These words echo the sentiments of `poetry's` creator Sébastien Eustace and the motivation for creating the tool:\n",
     "\n",
     "> *\"Packaging systems and dependency management in Python are rather convoluted and hard to understand for newcomers. Even for seasoned developers it might be cumbersome at times to create all files needed in a Python project: setup.py, requirements.txt, setup.cfg, MANIFEST.in, and the newly added Pipfile. So I wanted a tool that would limit everything to a single configuration file to do: dependency management, packaging and publishing.\"*\n",
     "\n",
-    "That \"single configuration file\" is `pyproject.toml` (you can read more about `.toml` files [here](https://www.python.org/dev/peps/pep-0518/)). Essentially, `poetry` is based on all the concepts of `sdists` and `wheels` discussed previously - it just simplifies and streamlines the whole packaging process in an intuitive way. In fact, the `poetry build` command you used previously in Chapter 3: {ref}`03:how-to-package-a-python`, actually creates the `sdist` and `wheel` distributions of your package for you. It really is simple to create and distribute Python packages with `poetry` - go back and check out {ref}`03:how-to-package-a-python` for our recommended workflow, or check out the [poetry docs](https://python-poetry.org/docs/).\n",
+    "That \"single configuration file\" is `pyproject.toml` (you can read more about `.toml` files [here](https://www.python.org/dev/peps/pep-0518/)). Essentially, `poetry` is based on all the concepts of `sdists` and `wheels` discussed previously - it just simplifies and streamlines the whole packaging process in an intuitive way. In fact, the `poetry build` command you used previously in **Chapter 3: {ref}`03:How to package a Python`**, actually creates the `sdist` and `wheel` distributions of your package for you. It really is simple to create and distribute Python packages with `poetry` - go back and check out **Chapter 3: {ref}`03:How to package a Python`** for our recommended workflow, or check out the [poetry docs](https://python-poetry.org/docs/).\n",
     "\n",
     "```{figure} images/python-packages.png\n",
     "---\n",

--- a/py-pkgs/04-package-structure.ipynb
+++ b/py-pkgs/04-package-structure.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(04:Package structure and state)=\n",
+    "(04:Package-structure-and-state)=\n",
     "# Package structure and state"
    ]
   },
@@ -145,7 +145,7 @@
     "A \"distribution package\" (often referred to simply as a \"distribution\") is a single archive of the Python packages, modules and other files that make up your project. Having a single archive makes it easier to distribute your code to the world. The fundamental distribution format is called a \"source distribution\" (`sdist`). An `sdist` is a compressed archive (e.g., `.tar.gz` or `.zip`) of your package. Essentially, an `sdist` provides all of the metadata and source files needed for building and installing your package. You can read more about source distributions [here](https://docs.python.org/3/distutils/sourcedist.html). The standard tool in Python for creating `sdists` (and binary distributions, which we'll explore in the next section) is `setuptools`. \n",
     "\n",
     "```{note}\n",
-    "As we saw in **Chapter 3: {ref}`03:How to package a Python`**, we prefer to use `poetry` to create distribution packages of our Python code, as a simpler and more intuitive alternative to `setuptools`. We'll discuss Poetry a little later.\n",
+    "As we saw in **Chapter 3: {ref}`03:How-to-package-a-Python`**, we prefer to use `poetry` to create distribution packages of our Python code, as a simpler and more intuitive alternative to `setuptools`. We'll discuss Poetry a little later.\n",
     "```\n",
     "\n",
     "As a very simple example, consider the following directory which now contains a `setup.py` file.\n",
@@ -246,11 +246,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The previous sections gave a high level overview of Python's standard packaging options and tools. However, in **Chapter 3: {ref}`03:How to package a Python`** we used `poetry` to create a toy Python package - so where does this tool fit into the Python packaging landscape? Well, in the previous sections, we really only touched the tip of the iceberg of Python packaging. When creating a package there's a lot of customisation to think about with your `setup.py` file, and a host of other files we didn't even talk about (e.g., `requirements.txt`, `setup.cfg`, etc)! Needless to say, packaging in Python can be hard to understand, especially for beginners. These words echo the sentiments of `poetry's` creator Sébastien Eustace and the motivation for creating the tool:\n",
+    "The previous sections gave a high level overview of Python's standard packaging options and tools. However, in **Chapter 3: {ref}`03:How-to-package-a-Python`** we used `poetry` to create a toy Python package - so where does this tool fit into the Python packaging landscape? Well, in the previous sections, we really only touched the tip of the iceberg of Python packaging. When creating a package there's a lot of customisation to think about with your `setup.py` file, and a host of other files we didn't even talk about (e.g., `requirements.txt`, `setup.cfg`, etc)! Needless to say, packaging in Python can be hard to understand, especially for beginners. These words echo the sentiments of `poetry's` creator Sébastien Eustace and the motivation for creating the tool:\n",
     "\n",
     "> *\"Packaging systems and dependency management in Python are rather convoluted and hard to understand for newcomers. Even for seasoned developers it might be cumbersome at times to create all files needed in a Python project: setup.py, requirements.txt, setup.cfg, MANIFEST.in, and the newly added Pipfile. So I wanted a tool that would limit everything to a single configuration file to do: dependency management, packaging and publishing.\"*\n",
     "\n",
-    "That \"single configuration file\" is `pyproject.toml` (you can read more about `.toml` files [here](https://www.python.org/dev/peps/pep-0518/)). Essentially, `poetry` is based on all the concepts of `sdists` and `wheels` discussed previously - it just simplifies and streamlines the whole packaging process in an intuitive way. In fact, the `poetry build` command you used previously in **Chapter 3: {ref}`03:How to package a Python`**, actually creates the `sdist` and `wheel` distributions of your package for you. It really is simple to create and distribute Python packages with `poetry` - go back and check out **Chapter 3: {ref}`03:How to package a Python`** for our recommended workflow, or check out the [poetry docs](https://python-poetry.org/docs/).\n",
+    "That \"single configuration file\" is `pyproject.toml` (you can read more about `.toml` files [here](https://www.python.org/dev/peps/pep-0518/)). Essentially, `poetry` is based on all the concepts of `sdists` and `wheels` discussed previously - it just simplifies and streamlines the whole packaging process in an intuitive way. In fact, the `poetry build` command you used previously in **Chapter 3: {ref}`03:How-to-package-a-Python`**, actually creates the `sdist` and `wheel` distributions of your package for you. It really is simple to create and distribute Python packages with `poetry` - go back and check out **Chapter 3: {ref}`03:How-to-package-a-Python`** for our recommended workflow, or check out the [poetry docs](https://python-poetry.org/docs/).\n",
     "\n",
     "```{figure} images/python-packages.png\n",
     "---\n",

--- a/py-pkgs/05-testing.ipynb
+++ b/py-pkgs/05-testing.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(05:testing)=\n",
+    "(05:Testing)=\n",
     "# Testing"
    ]
   },
@@ -18,7 +18,7 @@
     "2. **Better code structure:** writing tests forces you to structure and compartmentalise your code so that it's easier to test and understand;\n",
     "3. **Easier development:** formal tests will help others (and your future self) add features to your code without breaking the tried-and-tested base functionality.\n",
     "\n",
-    "Chapter 3: {ref}`03:how-to-package-a-python`, briefly introduced unit testing in Python package development. This chapter now describes in more detail how to implement formal and automated testing into a Python workflow. This chapter is inspired by the [Testing chapter](https://r-pkgs.org/tests.html) of the [R packages book](https://r-pkgs.org/) written by Jenny Bryan and the [`pytest` package documentation](https://docs.pytest.org/en/latest/)."
+    "**Chapter 3: {ref}`03:How to package a Python`** briefly introduced unit testing in Python package development. This chapter now describes in more detail how to implement formal and automated testing into a Python workflow. This chapter is inspired by the [Testing chapter](https://r-pkgs.org/tests.html) of the [R packages book](https://r-pkgs.org/) written by Jenny Bryan and the [`pytest` package documentation](https://docs.pytest.org/en/latest/)."
    ]
   },
   {
@@ -59,7 +59,7 @@
     "2. Write and run tests; and,\n",
     "3. Determine test code coverage.\n",
     "\n",
-    "We'll describe each step in a little more detail below, but be aware that the whole testing workflow is an iterative procedure. As you develop your code, add features, and find bugs, you'll be writing additional tests, checking the code coverage, writing more tests, etc. In the rest of this chapter we'll be revisiting and building on the toy Python package `pypkgs` you created in {ref}`03:how-to-package-a-python`."
+    "We'll describe each step in a little more detail below, but be aware that the whole testing workflow is an iterative procedure. As you develop your code, add features, and find bugs, you'll be writing additional tests, checking the code coverage, writing more tests, etc. In the rest of this chapter we'll be revisiting and building on the toy Python package `pypkgs` you created in **Chapter 3: {ref}`03:How to package a Python`**."
    ]
   },
   {
@@ -73,7 +73,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`pytest` will run all files of the form `test_*.py` or `*_test.py` in the current directory and its subdirectories. Standard practice for Python packages is to place test modules in a `test` subdirectory within the root package directory. The [MDS Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) that we downloaded and used in {ref}`03:how-to-package-a-python` to build our `pypkgs` package automatically created this directory structure for us:\n",
+    "`pytest` will run all files of the form `test_*.py` or `*_test.py` in the current directory and its subdirectories. Standard practice for Python packages is to place test modules in a `test` subdirectory within the root package directory. The [MDS Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) that we downloaded and used in **Chapter 3: {ref}`03:How to package a Python`** to build our `pypkgs` package automatically created this directory structure for us:\n",
     "\n",
     "```bash\n",
     "pypkgs\n",
@@ -94,7 +94,7 @@
     "    └── test_pypkgs.py\n",
     "```\n",
     "\n",
-    "Large libraries often split tests up into multiple `test_*.py` or `*_test.py` files within the `tests` directory to better organise tests. However, for many Python packages a single file will suffice, which by default is named `test_yourpackagename.py`. Recall that in {ref}`03:how-to-package-a-python` we added the following test of our `catbind()` function in the file `test_pypkgs.py`:\n",
+    "Large libraries often split tests up into multiple `test_*.py` or `*_test.py` files within the `tests` directory to better organise tests. However, for many Python packages a single file will suffice, which by default is named `test_yourpackagename.py`. Recall that in **Chapter 3: {ref}`03:How to package a Python`** we added the following test of our `catbind()` function in the file `test_pypkgs.py`:\n",
     "\n",
     "```python\n",
     "from pypkgs import pypkgs\n",

--- a/py-pkgs/05-testing.ipynb
+++ b/py-pkgs/05-testing.ipynb
@@ -18,7 +18,7 @@
     "2. **Better code structure:** writing tests forces you to structure and compartmentalise your code so that it's easier to test and understand;\n",
     "3. **Easier development:** formal tests will help others (and your future self) add features to your code without breaking the tried-and-tested base functionality.\n",
     "\n",
-    "**Chapter 3: {ref}`03:How to package a Python`** briefly introduced unit testing in Python package development. This chapter now describes in more detail how to implement formal and automated testing into a Python workflow. This chapter is inspired by the [Testing chapter](https://r-pkgs.org/tests.html) of the [R packages book](https://r-pkgs.org/) written by Jenny Bryan and the [`pytest` package documentation](https://docs.pytest.org/en/latest/)."
+    "**Chapter 3: {ref}`03:How-to-package-a-Python`** briefly introduced unit testing in Python package development. This chapter now describes in more detail how to implement formal and automated testing into a Python workflow. This chapter is inspired by the [Testing chapter](https://r-pkgs.org/tests.html) of the [R packages book](https://r-pkgs.org/) written by Jenny Bryan and the [`pytest` package documentation](https://docs.pytest.org/en/latest/)."
    ]
   },
   {
@@ -59,7 +59,7 @@
     "2. Write and run tests; and,\n",
     "3. Determine test code coverage.\n",
     "\n",
-    "We'll describe each step in a little more detail below, but be aware that the whole testing workflow is an iterative procedure. As you develop your code, add features, and find bugs, you'll be writing additional tests, checking the code coverage, writing more tests, etc. In the rest of this chapter we'll be revisiting and building on the toy Python package `pypkgs` you created in **Chapter 3: {ref}`03:How to package a Python`**."
+    "We'll describe each step in a little more detail below, but be aware that the whole testing workflow is an iterative procedure. As you develop your code, add features, and find bugs, you'll be writing additional tests, checking the code coverage, writing more tests, etc. In the rest of this chapter we'll be revisiting and building on the toy Python package `pypkgs` you created in **Chapter 3: {ref}`03:How-to-package-a-Python`**."
    ]
   },
   {
@@ -73,7 +73,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`pytest` will run all files of the form `test_*.py` or `*_test.py` in the current directory and its subdirectories. Standard practice for Python packages is to place test modules in a `test` subdirectory within the root package directory. The [MDS Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) that we downloaded and used in **Chapter 3: {ref}`03:How to package a Python`** to build our `pypkgs` package automatically created this directory structure for us:\n",
+    "`pytest` will run all files of the form `test_*.py` or `*_test.py` in the current directory and its subdirectories. Standard practice for Python packages is to place test modules in a `test` subdirectory within the root package directory. The [MDS Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) that we downloaded and used in **Chapter 3: {ref}`03:How-to-package-a-Python`** to build our `pypkgs` package automatically created this directory structure for us:\n",
     "\n",
     "```bash\n",
     "pypkgs\n",
@@ -94,7 +94,7 @@
     "    └── test_pypkgs.py\n",
     "```\n",
     "\n",
-    "Large libraries often split tests up into multiple `test_*.py` or `*_test.py` files within the `tests` directory to better organise tests. However, for many Python packages a single file will suffice, which by default is named `test_yourpackagename.py`. Recall that in **Chapter 3: {ref}`03:How to package a Python`** we added the following test of our `catbind()` function in the file `test_pypkgs.py`:\n",
+    "Large libraries often split tests up into multiple `test_*.py` or `*_test.py` files within the `tests` directory to better organise tests. However, for many Python packages a single file will suffice, which by default is named `test_yourpackagename.py`. Recall that in **Chapter 3: {ref}`03:How-to-package-a-Python`** we added the following test of our `catbind()` function in the file `test_pypkgs.py`:\n",
     "\n",
     "```python\n",
     "from pypkgs import pypkgs\n",

--- a/py-pkgs/06-documentation.ipynb
+++ b/py-pkgs/06-documentation.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(06:documentation)=\n",
+    "(06:Documentation)=\n",
     "# Documentation"
    ]
   },
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Documentation is one of the most important aspects of a good package. For the users of your code (including your future self) it is necessary to have readable and accessible documentation expressing what your package does, how to install your package, and how to use the user-facing functions within it. Back in Chapter 3: {ref}`03:how-to-package-a-python` we briefly introduced documentation in Python package development. This chapter now describes package documentation in more detail. This chapter is inspired by the [Object documentation chapter](https://r-pkgs.org/man.html) of the [R packages book](https://r-pkgs.org/)."
+    "Documentation is one of the most important aspects of a good package. For the users of your code (including your future self) it is necessary to have readable and accessible documentation expressing what your package does, how to install your package, and how to use the user-facing functions within it. Back in **Chapter 3: {ref}`03:How to package a Python`** we briefly introduced documentation in Python package development. This chapter now describes package documentation in more detail. This chapter is inspired by the [Object documentation chapter](https://r-pkgs.org/man.html) of the [R packages book](https://r-pkgs.org/)."
    ]
   },
   {
@@ -34,7 +34,7 @@
     "- Contributors (optional)\n",
     "- Contributing (optional)\n",
     "\n",
-    "Each of these files are described in more detail below. Note that the [Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) we used previously in Chapter 3: {ref}`03:how-to-package-a-python` automatically creates and populates these files for you."
+    "Each of these files are described in more detail below. Note that the [Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) we used previously in **Chapter 3: {ref}`03:How to package a Python`** automatically creates and populates these files for you."
    ]
   },
   {
@@ -272,7 +272,7 @@
     "The --dev argument is used to specify a development dependency, i.e., a package that is not required by a user to use your package, but is required for development purposes.\n",
     "```\n",
     "\n",
-    "Your documentation typically lives in a subdirectory called `docs` in the root package directory. At a minimum this `docs` subdirectory typically includes a `conf.py` file (which configures how Sphinx reads and builds your documentation), an `index.rst` file (a master document which will serve as the \"welcome page\" of your documentation and typically includes a “table of contents” linking to the various parts of your documentation), and a `Makefile` and `make.bat` file which help Sphinx to build your documentation. Other than these files, you can include as many additional files into your `docs` subdirectory as you like. The [MDS Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) that we downloaded and used in {ref}`03:how-to-package-a-python` automatically created the `docs` subdirectory for you, and populated it with a number of files to help you quickly build your documentation. Feel free to open these files up to have a look at what's inside!\n",
+    "Your documentation typically lives in a subdirectory called `docs` in the root package directory. At a minimum this `docs` subdirectory typically includes a `conf.py` file (which configures how Sphinx reads and builds your documentation), an `index.rst` file (a master document which will serve as the \"welcome page\" of your documentation and typically includes a “table of contents” linking to the various parts of your documentation), and a `Makefile` and `make.bat` file which help Sphinx to build your documentation. Other than these files, you can include as many additional files into your `docs` subdirectory as you like. The [MDS Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) that we downloaded and used in **Chapter 3: {ref}`03:How to package a Python`** automatically created the `docs` subdirectory for you, and populated it with a number of files to help you quickly build your documentation. Feel free to open these files up to have a look at what's inside!\n",
     "\n",
     "```bash\n",
     "└── docs\n",

--- a/py-pkgs/06-documentation.ipynb
+++ b/py-pkgs/06-documentation.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Documentation is one of the most important aspects of a good package. For the users of your code (including your future self) it is necessary to have readable and accessible documentation expressing what your package does, how to install your package, and how to use the user-facing functions within it. Back in **Chapter 3: {ref}`03:How to package a Python`** we briefly introduced documentation in Python package development. This chapter now describes package documentation in more detail. This chapter is inspired by the [Object documentation chapter](https://r-pkgs.org/man.html) of the [R packages book](https://r-pkgs.org/)."
+    "Documentation is one of the most important aspects of a good package. For the users of your code (including your future self) it is necessary to have readable and accessible documentation expressing what your package does, how to install your package, and how to use the user-facing functions within it. Back in **Chapter 3: {ref}`03:How-to-package-a-Python`** we briefly introduced documentation in Python package development. This chapter now describes package documentation in more detail. This chapter is inspired by the [Object documentation chapter](https://r-pkgs.org/man.html) of the [R packages book](https://r-pkgs.org/)."
    ]
   },
   {
@@ -34,7 +34,7 @@
     "- Contributors (optional)\n",
     "- Contributing (optional)\n",
     "\n",
-    "Each of these files are described in more detail below. Note that the [Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) we used previously in **Chapter 3: {ref}`03:How to package a Python`** automatically creates and populates these files for you."
+    "Each of these files are described in more detail below. Note that the [Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) we used previously in **Chapter 3: {ref}`03:How-to-package-a-Python`** automatically creates and populates these files for you."
    ]
   },
   {
@@ -272,7 +272,7 @@
     "The --dev argument is used to specify a development dependency, i.e., a package that is not required by a user to use your package, but is required for development purposes.\n",
     "```\n",
     "\n",
-    "Your documentation typically lives in a subdirectory called `docs` in the root package directory. At a minimum this `docs` subdirectory typically includes a `conf.py` file (which configures how Sphinx reads and builds your documentation), an `index.rst` file (a master document which will serve as the \"welcome page\" of your documentation and typically includes a “table of contents” linking to the various parts of your documentation), and a `Makefile` and `make.bat` file which help Sphinx to build your documentation. Other than these files, you can include as many additional files into your `docs` subdirectory as you like. The [MDS Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) that we downloaded and used in **Chapter 3: {ref}`03:How to package a Python`** automatically created the `docs` subdirectory for you, and populated it with a number of files to help you quickly build your documentation. Feel free to open these files up to have a look at what's inside!\n",
+    "Your documentation typically lives in a subdirectory called `docs` in the root package directory. At a minimum this `docs` subdirectory typically includes a `conf.py` file (which configures how Sphinx reads and builds your documentation), an `index.rst` file (a master document which will serve as the \"welcome page\" of your documentation and typically includes a “table of contents” linking to the various parts of your documentation), and a `Makefile` and `make.bat` file which help Sphinx to build your documentation. Other than these files, you can include as many additional files into your `docs` subdirectory as you like. The [MDS Cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) that we downloaded and used in **Chapter 3: {ref}`03:How-to-package-a-Python`** automatically created the `docs` subdirectory for you, and populated it with a number of files to help you quickly build your documentation. Feel free to open these files up to have a look at what's inside!\n",
     "\n",
     "```bash\n",
     "└── docs\n",

--- a/py-pkgs/07-releasing-versioning.ipynb
+++ b/py-pkgs/07-releasing-versioning.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(07:releasing-and-versioning)=\n",
+    "(07:Releasing and versioning)=\n",
     "# Releasing and versioning"
    ]
   },
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Packages exist so that you can share your code with others. Previous chapters have focussed on how to develop your Python package for distribution - we are now ready to release the package to users (which might include your future self, others in your company, or the world). In the {ref}`03:how-to-package-a-python` we briefly showed how to release a package to PyPI, Python's main package index. This chapter now describes in more detail the process of releasing a package and is inspired by the [Releasing a package chapter](https://r-pkgs.org/release.html) of the [R packages book](https://r-pkgs.org/). In the follow chapter {ref}`08:continuous-integration-and-deployment` we show how the process of developing and releasing a package can be automated."
+    "Packages exist so that you can share your code with others. Previous chapters have focussed on how to develop your Python package for distribution - we are now ready to release the package to users (which might include your future self, others in your company, or the world). In **Chapter 3: {ref}`03:How to package a Python`** we briefly showed how to release a package to PyPI, Python's main package index. This chapter now describes in more detail the process of releasing a package and is inspired by the [Releasing a package chapter](https://r-pkgs.org/release.html) of the [R packages book](https://r-pkgs.org/). In **Chapter 8: {ref}`08:Continuous integration and deployment`** we show how the process of developing and releasing a package can be automated."
    ]
   },
   {
@@ -28,7 +28,7 @@
    "source": [
     "When you're ready to release your software, you first need to decide where to release it to. The Python Package Index ([PyPI](https://pypi.org/)) is the official, open-source, software repository for Python (as CRAN is the repository for R). If you're interested in sharing your work publicly, this is probably where you'll be releasing your package. \n",
     "\n",
-    "We'll focus on releasing packages to PyPI in this chapter, however PyPI is not the only option. Another popular software repository for Python (and other languages) packages is that hosted by [Anaconda](https://www.anaconda.com/) and accessible with the [conda package manager](https://docs.conda.io/en/latest/) (which we installed back in Chapter 2: {ref}`02:system-setup`). We won't go into the details of the differences between these two popular repositories here, but if you're interested to read more, we recommend [this article](https://www.anaconda.com/blog/understanding-conda-and-pip). Creating packages for Anaconda requires a little more work than for PyPI - Anaconda provides a [helpful tutorial](https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html) on the workflow.\n",
+    "We'll focus on releasing packages to PyPI in this chapter, however PyPI is not the only option. Another popular software repository for Python (and other languages) packages is that hosted by [Anaconda](https://www.anaconda.com/) and accessible with the [conda package manager](https://docs.conda.io/en/latest/) (which we installed back in **Chapter 2: {ref}`02:System setup`**). We won't go into the details of the differences between these two popular repositories here, but if you're interested to read more, we recommend [this article](https://www.anaconda.com/blog/understanding-conda-and-pip). Creating packages for Anaconda requires a little more work than for PyPI - Anaconda provides a [helpful tutorial](https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html) on the workflow.\n",
     "\n",
     "In some cases, you may want to release your package to a private repository (for example, for internal use by your company only). There are many private repository options for Python packages. Companies like [Anaconda](https://docs.anaconda.com/), [PyDist](https://pydist.com/) and [GemFury](https://gemfury.com/) are all examples that offer (typically paid) private Python package repository hosting. You can also set up your own server on a dedicated machine or cloud service like AWS - read more [here](https://medium.com/swlh/how-to-install-a-private-pypi-server-on-aws-76993e45c610).\n",
     "\n",
@@ -54,7 +54,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Versioning is the process of adding unique identifiers to different versions of your package. The unique identifier you use may be name-based or number-based. Python prefers number-based schemes and we saw an example of this in {ref}`03:how-to-package-a-python` chapter where we assigned our `pypkgs` package an intial version number of 0.1.0 (the default when using the `poetry` package manager). This three-number versioning scheme (also referred to as semantic versioning) is the most common scheme used and the idea is to incrementally increase the version number in a logical way as you make changes to your package.\n",
+    "Versioning is the process of adding unique identifiers to different versions of your package. The unique identifier you use may be name-based or number-based. Python prefers number-based schemes and we saw an example of this in **Chapter 3: {ref}`03:How to package a Python`** where we assigned our `pypkgs` package an intial version number of 0.1.0 (the default when using the `poetry` package manager). This three-number versioning scheme (also referred to as semantic versioning) is the most common scheme used and the idea is to incrementally increase the version number in a logical way as you make changes to your package.\n",
     "\n",
     "When you do make changes to your package, how do you decide how to increment the version? Will our next version be 0.1.1, 0.2.0, or 1.1.0? Here are the general guidelines for increment package version:\n",
     "\n",
@@ -263,7 +263,7 @@
     "poetry config repositories.test-pypi https://test.pypi.org/legacy/\n",
     "```\n",
     "\n",
-    "Before we send our package to testPyPI, we first need to build it to source and wheel distributions (the format that PyPI distributes and something we learned about in the Chapter 4: {ref}`04:package-structure-and-state`) using `poetry build`:\n",
+    "Before we send our package to testPyPI, we first need to build it to source and wheel distributions (the format that PyPI distributes and something we learned about in the **Chapter 4: {ref}`04:Package structure and state`**) using `poetry build`:\n",
     "\n",
     "```bash\n",
     "poetry build\n",
@@ -292,7 +292,7 @@
     "```\n",
     "\n",
     "```{note}\n",
-    "In the next chapter {ref}`08:continuous-integration-and-deployment` we'll see how we can automate the building and publishing of package releases to testPyPI and PyPI.\n",
+    "In **Chapter 8: {ref}`08:Continuous integration and deployment`** we'll see how we can automate the building and publishing of package releases to testPyPI and PyPI.\n",
     "```"
    ]
   },

--- a/py-pkgs/07-releasing-versioning.ipynb
+++ b/py-pkgs/07-releasing-versioning.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(07:Releasing and versioning)=\n",
+    "(07:Releasing-and-versioning)=\n",
     "# Releasing and versioning"
    ]
   },
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Packages exist so that you can share your code with others. Previous chapters have focussed on how to develop your Python package for distribution - we are now ready to release the package to users (which might include your future self, others in your company, or the world). In **Chapter 3: {ref}`03:How to package a Python`** we briefly showed how to release a package to PyPI, Python's main package index. This chapter now describes in more detail the process of releasing a package and is inspired by the [Releasing a package chapter](https://r-pkgs.org/release.html) of the [R packages book](https://r-pkgs.org/). In **Chapter 8: {ref}`08:Continuous integration and deployment`** we show how the process of developing and releasing a package can be automated."
+    "Packages exist so that you can share your code with others. Previous chapters have focussed on how to develop your Python package for distribution - we are now ready to release the package to users (which might include your future self, others in your company, or the world). In **Chapter 3: {ref}`03:How-to-package-a-Python`** we briefly showed how to release a package to PyPI, Python's main package index. This chapter now describes in more detail the process of releasing a package and is inspired by the [Releasing a package chapter](https://r-pkgs.org/release.html) of the [R packages book](https://r-pkgs.org/). In **Chapter 8: {ref}`08:Continuous-integration-and-deployment`** we show how the process of developing and releasing a package can be automated."
    ]
   },
   {
@@ -28,7 +28,7 @@
    "source": [
     "When you're ready to release your software, you first need to decide where to release it to. The Python Package Index ([PyPI](https://pypi.org/)) is the official, open-source, software repository for Python (as CRAN is the repository for R). If you're interested in sharing your work publicly, this is probably where you'll be releasing your package. \n",
     "\n",
-    "We'll focus on releasing packages to PyPI in this chapter, however PyPI is not the only option. Another popular software repository for Python (and other languages) packages is that hosted by [Anaconda](https://www.anaconda.com/) and accessible with the [conda package manager](https://docs.conda.io/en/latest/) (which we installed back in **Chapter 2: {ref}`02:System setup`**). We won't go into the details of the differences between these two popular repositories here, but if you're interested to read more, we recommend [this article](https://www.anaconda.com/blog/understanding-conda-and-pip). Creating packages for Anaconda requires a little more work than for PyPI - Anaconda provides a [helpful tutorial](https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html) on the workflow.\n",
+    "We'll focus on releasing packages to PyPI in this chapter, however PyPI is not the only option. Another popular software repository for Python (and other languages) packages is that hosted by [Anaconda](https://www.anaconda.com/) and accessible with the [conda package manager](https://docs.conda.io/en/latest/) (which we installed back in **Chapter 2: {ref}`02:System-setup`**). We won't go into the details of the differences between these two popular repositories here, but if you're interested to read more, we recommend [this article](https://www.anaconda.com/blog/understanding-conda-and-pip). Creating packages for Anaconda requires a little more work than for PyPI - Anaconda provides a [helpful tutorial](https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html) on the workflow.\n",
     "\n",
     "In some cases, you may want to release your package to a private repository (for example, for internal use by your company only). There are many private repository options for Python packages. Companies like [Anaconda](https://docs.anaconda.com/), [PyDist](https://pydist.com/) and [GemFury](https://gemfury.com/) are all examples that offer (typically paid) private Python package repository hosting. You can also set up your own server on a dedicated machine or cloud service like AWS - read more [here](https://medium.com/swlh/how-to-install-a-private-pypi-server-on-aws-76993e45c610).\n",
     "\n",
@@ -54,7 +54,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Versioning is the process of adding unique identifiers to different versions of your package. The unique identifier you use may be name-based or number-based. Python prefers number-based schemes and we saw an example of this in **Chapter 3: {ref}`03:How to package a Python`** where we assigned our `pypkgs` package an intial version number of 0.1.0 (the default when using the `poetry` package manager). This three-number versioning scheme (also referred to as semantic versioning) is the most common scheme used and the idea is to incrementally increase the version number in a logical way as you make changes to your package.\n",
+    "Versioning is the process of adding unique identifiers to different versions of your package. The unique identifier you use may be name-based or number-based. Python prefers number-based schemes and we saw an example of this in **Chapter 3: {ref}`03:How-to-package-a-Python`** where we assigned our `pypkgs` package an intial version number of 0.1.0 (the default when using the `poetry` package manager). This three-number versioning scheme (also referred to as semantic versioning) is the most common scheme used and the idea is to incrementally increase the version number in a logical way as you make changes to your package.\n",
     "\n",
     "When you do make changes to your package, how do you decide how to increment the version? Will our next version be 0.1.1, 0.2.0, or 1.1.0? Here are the general guidelines for increment package version:\n",
     "\n",
@@ -263,7 +263,7 @@
     "poetry config repositories.test-pypi https://test.pypi.org/legacy/\n",
     "```\n",
     "\n",
-    "Before we send our package to testPyPI, we first need to build it to source and wheel distributions (the format that PyPI distributes and something we learned about in the **Chapter 4: {ref}`04:Package structure and state`**) using `poetry build`:\n",
+    "Before we send our package to testPyPI, we first need to build it to source and wheel distributions (the format that PyPI distributes and something we learned about in the **Chapter 4: {ref}`04:Package-structure-and-state`**) using `poetry build`:\n",
     "\n",
     "```bash\n",
     "poetry build\n",
@@ -292,7 +292,7 @@
     "```\n",
     "\n",
     "```{note}\n",
-    "In **Chapter 8: {ref}`08:Continuous integration and deployment`** we'll see how we can automate the building and publishing of package releases to testPyPI and PyPI.\n",
+    "In **Chapter 8: {ref}`08:Continuous-integration-and-deployment`** we'll see how we can automate the building and publishing of package releases to testPyPI and PyPI.\n",
     "```"
    ]
   },

--- a/py-pkgs/08-ci-cd.ipynb
+++ b/py-pkgs/08-ci-cd.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(08:continuous-integration-and-deployment)=\n",
+    "(08:Continuous integration and deployment)=\n",
     "# Continuous integration and deployment"
    ]
   },
@@ -58,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Back in Chapter 3: {ref}`03:how-to-package-a-python` when we used the [UBC-MDS cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) to create our Python package `pypkgs`, we chose to **not** include a GitHub Actions workflow file in our package template. Recall the following exerpt from when we were specifying cookiecutter template options:\n",
+    "Back in **Chapter 3: {ref}`03:How to package a Python`** when we used the [UBC-MDS cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) to create our Python package `pypkgs`, we chose to **not** include a GitHub Actions workflow file in our package template. Recall the following exerpt from when we were specifying cookiecutter template options:\n",
     "\n",
     "```bash\n",
     "Select include_github_actions:\n",
@@ -212,7 +212,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Remember all the hard work we put into writing tests for our package back in the Chapter 5: {ref}`05:testing`? Well, we likely want to make sure that these tests (and any others that we add) continue to pass for any new updates to our code. Just like we did with `flake8` we can automatically run our tests every time somebody pushes code updates or makes a pull request to our repository. The set up here is pretty easy! Recall that we used `pytest` as our testing framework, and this is listed as a development dependency for our package so will already be installed by our CI workflow in the \"Install dependencies\" step. Therefore, we just need to add the `pytest` command as a step in our `build.yml` file:\n",
+    "Remember all the hard work we put into writing tests for our package back in the **Chapter 5: {ref}`05:Testing`**? Well, we likely want to make sure that these tests (and any others that we add) continue to pass for any new updates to our code. Just like we did with `flake8` we can automatically run our tests every time somebody pushes code updates or makes a pull request to our repository. The set up here is pretty easy! Recall that we used `pytest` as our testing framework, and this is listed as a development dependency for our package so will already be installed by our CI workflow in the \"Install dependencies\" step. Therefore, we just need to add the `pytest` command as a step in our `build.yml` file:\n",
     "\n",
     "```\n",
     "    - name: Test with pytest\n",
@@ -358,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Whereas CI verifies that your updated code is working as expected, Continuous Deployment (CD) takes that updated code and deploys it into production. In the case of Python packaging, that typically means building and pushing an updated package version to PyPI. In the Chapter 7: {ref}`07:releasing-and-versioning` we discussed how to version and release a Python package. Here, we are going to automate this process with a GitHub Actions workflow.\n",
+    "Whereas CI verifies that your updated code is working as expected, Continuous Deployment (CD) takes that updated code and deploys it into production. In the case of Python packaging, that typically means building and pushing an updated package version to PyPI. In the **Chapter 7: {ref}`07:Releasing and versioning`** we discussed how to version and release a Python package. Here, we are going to automate this process with a GitHub Actions workflow.\n",
     "\n",
     "```{note}\n",
     "Some developers prefer to manually deploy their product rather than automate deployment with CD. However, they'll still use the terms CI/CD - typically the CD here stands for \"Continuous Delivery\" which essentially gets the product deployment-ready, but requires the developer to manually \"push a button\" to deploy the software.\n",

--- a/py-pkgs/08-ci-cd.ipynb
+++ b/py-pkgs/08-ci-cd.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(08:Continuous integration and deployment)=\n",
+    "(08:Continuous-integration-and-deployment)=\n",
     "# Continuous integration and deployment"
    ]
   },
@@ -58,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Back in **Chapter 3: {ref}`03:How to package a Python`** when we used the [UBC-MDS cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) to create our Python package `pypkgs`, we chose to **not** include a GitHub Actions workflow file in our package template. Recall the following exerpt from when we were specifying cookiecutter template options:\n",
+    "Back in **Chapter 3: {ref}`03:How-to-package-a-Python`** when we used the [UBC-MDS cookiecutter template](https://github.com/UBC-MDS/cookiecutter-ubc-mds) to create our Python package `pypkgs`, we chose to **not** include a GitHub Actions workflow file in our package template. Recall the following exerpt from when we were specifying cookiecutter template options:\n",
     "\n",
     "```bash\n",
     "Select include_github_actions:\n",
@@ -358,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Whereas CI verifies that your updated code is working as expected, Continuous Deployment (CD) takes that updated code and deploys it into production. In the case of Python packaging, that typically means building and pushing an updated package version to PyPI. In the **Chapter 7: {ref}`07:Releasing and versioning`** we discussed how to version and release a Python package. Here, we are going to automate this process with a GitHub Actions workflow.\n",
+    "Whereas CI verifies that your updated code is working as expected, Continuous Deployment (CD) takes that updated code and deploys it into production. In the case of Python packaging, that typically means building and pushing an updated package version to PyPI. In the **Chapter 7: {ref}`07:Releasing-and-versioning`** we discussed how to version and release a Python package. Here, we are going to automate this process with a GitHub Actions workflow.\n",
     "\n",
     "```{note}\n",
     "Some developers prefer to manually deploy their product rather than automate deployment with CD. However, they'll still use the terms CI/CD - typically the CD here stands for \"Continuous Delivery\" which essentially gets the product deployment-ready, but requires the developer to manually \"push a button\" to deploy the software.\n",

--- a/py-pkgs/A1-cli.ipynb
+++ b/py-pkgs/A1-cli.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(A1:Packages with a command line interface)=\n",
+    "(A1:Packages-with-a-command-line-interface)=\n",
     "# Packages with a command line interface"
    ]
   },

--- a/py-pkgs/A1-cli.ipynb
+++ b/py-pkgs/A1-cli.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(A1:packages-with-a-command-line-interface)=\n",
+    "(A1:Packages with a command line interface)=\n",
     "# Packages with a command line interface"
    ]
   },

--- a/py-pkgs/A2-cheatsheet.ipynb
+++ b/py-pkgs/A2-cheatsheet.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(A2:python-packaging-cheat-sheet)=\n",
+    "(A2:Python packaging cheat sheet)=\n",
     "# Python packaging cheat sheet"
    ]
   },
@@ -17,7 +17,7 @@
     "name: cheat-sheet\n",
     "align: center\n",
     "---\n",
-    "[Download the cheat sheet from GitHub here!](https://github.com/UBC-MDS/py-pkgs/raw/master/py-pkgs/content/img/09-cheatsheet/py_pkgs_cheatsheet.pdf)\n",
+    "[Download the cheat sheet from GitHub here!](https://github.com/UBC-MDS/py-pkgs/blob/master/py-pkgs/images/raw/py_pkgs_cheatsheet.pdf)\n",
     "```"
    ]
   },
@@ -27,7 +27,7 @@
    "source": [
     "Here we provide a cheat sheet guide for developing a Python package with the packaging tools discussed in this book, such as [poetry](https://python-poetry.org/), [cookiecutter](https://cookiecutter.readthedocs.io/), and [GitHub Actions](https://docs.github.com/en/actions). This cheat sheet should be used as a reference for those that know what they're doing and just need a quick look-up resource. If you're a beginner Python packager, it is recommended that you start from the beginning of this book.\n",
     "\n",
-    "[**Download the cheat sheet from GitHub here.**](https://github.com/UBC-MDS/py-pkgs/blob/master/py-pkgs/chapters/img/09-cheatsheet/py_pkgs_cheatsheet.pdf)\n",
+    "[**Download the cheat sheet from GitHub here.**](https://github.com/UBC-MDS/py-pkgs/blob/master/py-pkgs/images/raw/py_pkgs_cheatsheet.pdf)\n",
     "\n",
     "```{note}\n",
     "While this cheat sheet specifically relies on [poetry](https://python-poetry.org/) as a Python package manager, builder, and publisher, the general packaging workflow shown is applicable to other packaging tools too.\n",

--- a/py-pkgs/A2-cheatsheet.ipynb
+++ b/py-pkgs/A2-cheatsheet.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(A2:Python packaging cheat sheet)=\n",
+    "(A2:Python-packaging-cheat-sheet)=\n",
     "# Python packaging cheat sheet"
    ]
   },

--- a/py-pkgs/welcome.ipynb
+++ b/py-pkgs/welcome.ipynb
@@ -4,7 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "(00:welcome)=\n",
     "# Welcome to Python Packages!"
    ]
   },


### PR DESCRIPTION
Changing the header referencing format from "{ref}`how-to-package-a-python`" to reflect the actual header "{ref}`How-to-package-a-Python`". This will make it easier to parse into .Rmd for the bookdown rendering and generally just makes more sense.