### PR TITLE
🔧 MAINTAIN: new toc format and add workflow_dispatch trigger to CI

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -11,6 +11,7 @@ on:
   schedule:
     # run once a month
     - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 # This job installs dependencies and builds the book
 jobs:

--- a/py-pkgs/_toc.yml
+++ b/py-pkgs/_toc.yml
@@ -1,12 +1,11 @@
-- file: welcome
-
-- part: Preface
-  numbered: false
+format: jb-book
+root: welcome
+parts:
+- caption: Preface
   chapters:
   - file: 00-preface
   - file: 00-authors
-
-- part: Chapters
+- caption: Chapters
   numbered: true
   chapters:
   - file: 01-introduction
@@ -17,9 +16,7 @@
   - file: 06-documentation
   - file: 07-releasing-versioning
   - file: 08-ci-cd
-  
-- part: Appendices
-  numbered: false
+- caption: Appendices
   chapters:
   - file: A1-cli
   - file: A2-cheatsheet


### PR DESCRIPTION
1. Update ToC format to new version used in jb 0.11.0 ([see here](https://jupyterbook.org/reference/_changelog.html#v0-11-0))
2. Add functionality to manually trigger testing workflow in GHA